### PR TITLE
(fix): Improve the check for `vite/` imports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 14] # 14
+        node-version: [18.x] # 14
         os: [ubuntu-latest] # mac
       fail-fast: false
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -35,12 +35,12 @@
         "@vue/compiler-dom": "^3.2.31"
     },
     "dependencies": {
-        "@jspm/generator": "^1.1.1"
+        "@jspm/generator": "^1.1.9"
     },
     "peerDependencies": {
         "vite": "*"
     },
     "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18"
     }
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -90,8 +90,8 @@ async function plugin(pluginOptions?: PluginOptions): Promise<Plugin[]> {
         if (
           id.startsWith("/") ||
           id.startsWith(".") ||
-          id.startsWith("vite/") ||
-          id.startsWith("__vite") ||
+          id.includes("vite/") ||
+          id.includes("__vite") ||
           id.includes(".css") ||
           id.includes(".html") ||
           path.isAbsolute(id) ||
@@ -127,7 +127,7 @@ async function plugin(pluginOptions?: PluginOptions): Promise<Plugin[]> {
           return null;
         }
 
-        if (id.startsWith("vite/") || path.isAbsolute(id)) {
+        if (id.includes("vite/") || path.isAbsolute(id)) {
           return;
         }
 
@@ -163,7 +163,7 @@ async function plugin(pluginOptions?: PluginOptions): Promise<Plugin[]> {
         return { id, external: true };
       },
       async load(id) {
-        if (id?.startsWith("vite/") || !id?.startsWith("http")) {
+        if (id?.includes("vite/") || !id?.includes("http")) {
           return;
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -60,8 +56,8 @@ importers:
   plugin:
     dependencies:
       '@jspm/generator':
-        specifier: ^1.1.1
-        version: 1.1.1(google-protobuf@3.21.2)
+        specifier: ^1.1.9
+        version: 1.1.9(google-protobuf@3.21.2)
       vite:
         specifier: '*'
         version: 4.1.1(@types/node@18.0.0)
@@ -836,8 +832,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.14
     dev: false
 
-  /@jspm/generator@1.1.1(google-protobuf@3.21.2):
-    resolution: {integrity: sha512-ni7DWLWT/Dh+QLpvC58g+5HPvojcSDauisJrEQnXqe4bdPQunQEoORi+9LqovM5baTPW2odXQQiQqpxOAhEvkA==}
+  /@jspm/generator@1.1.9(google-protobuf@3.21.2):
+    resolution: {integrity: sha512-ZSr+yeceUv/+h8tMH68bvzMWwe4rzW+ihx94N0f7ifGLUvT2r7I/tS7l1hpB0kMtL+DIfgS7ENt5gpQIXgrdrQ==}
     dependencies:
       '@babel/core': 7.21.3
       '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.21.3)
@@ -3458,3 +3454,7 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
fixes #11 

Upgraded `@jspm/generator` and changed the check for `vite/` imports. Looks like in version of `vite` from the `zip` from issue. The import `vite/preload-helper` has some special character

```js
import { __vitePreload } from "\0vite/preload-helper";
```